### PR TITLE
Fix cross-compilation referencing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ LD=$(CROSS_PREFIX)ld
 OBJCOPY=$(CROSS_PREFIX)objcopy
 OBJDUMP=$(CROSS_PREFIX)objdump
 STRIP=$(CROSS_PREFIX)strip
-CPP=cpp
+CPP=$(CROSS_PREFIX)cpp
 PYTHON=python3
 
 # Source files

--- a/scripts/check-gcc.sh
+++ b/scripts/check-gcc.sh
@@ -4,8 +4,8 @@
 f1="$1"
 f2="$2"
 
-s1=`readelf -A "$f1" | grep "Tag_ARM_ISA_use"`
-s2=`readelf -A "$f2" | grep "Tag_ARM_ISA_use"`
+s1=`${CROSS_PREFIX}readelf -A "$f1" | grep "Tag_ARM_ISA_use"`
+s2=`${CROSS_PREFIX}readelf -A "$f2" | grep "Tag_ARM_ISA_use"`
 
 if [ "$s1" != "$s2" ]; then
     echo ""


### PR DESCRIPTION
Cross compilation fails when `CROSS_PREFIX` is defined when under macOS.  
This is due to clang being the default compiler on macOS for C++. Therefore, it too needs the prefix appending.